### PR TITLE
Fix/check install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,3 +79,4 @@ vault_cluster_disable: false
 vault_cluster_addr: "{{ vault_protocol }}://{{ vault_cluster_address }}"
 #vault_redirect_address: "<lb ip address>"
 vault_api_addr: "{{ vault_protocol }}://{{ vault_redirect_address | default(hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address']) }}:{{ vault_port }}"
+vault_auto_unseal: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,12 +16,12 @@
 
 # Upgrade vault on nodes if the upgrade is required
 - name: Upgrade vault to version {{ vault_version }}
-  serial: 1
   include: upgrade.yml
   when: vault_upgrade_required is defined and vault_upgrade_required == true and vault_auto_unseal == true
+  serial: 1
 
 # Configuring vault only if install is required or if auto unseal is enabled
 - name: Ensure vault configuration files are defined as expected
-  serial: 1
   include: configure.yml
   when: vault_install_required == true or vault_auto_unseal == true
+  serial: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 # Upgrade vault on nodes if the upgrade is required
 - name: Upgrade vault to version {{ vault_version }}
   include: upgrade.yml
-  when: vault_upgrade_required is defined and vault_upgrade_required == true
+  when: vault_upgrade_required is defined and vault_upgrade_required == true and vault_auto_unseal == true
 
 # Configuring vault only if install is required or if auto unseal is enabled
 - name: Ensure vault configuration files are defined as expected

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   when: vault_install_required == true
 
 # Upgrade vault on nodes if the upgrade is required
-- name: Upgrade vault to version {{ vault_version }}
+- name: Upgrade vault to version "{{ vault_version }}"
   include: upgrade.yml
   when: vault_upgrade_required is defined and vault_upgrade_required == true and vault_auto_unseal == true
   serial: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 # Upgrade vault on nodes if the upgrade is required
 - name: Upgrade vault to version {{ vault_version }}
-  include: install.yml
+  include: upgrade.yml
   when: vault_upgrade_required is defined and vault_upgrade_required == true
 
 # Configuring vault only if install is required or if auto unseal is enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,10 +16,12 @@
 
 # Upgrade vault on nodes if the upgrade is required
 - name: Upgrade vault to version {{ vault_version }}
+  serial: 1
   include: upgrade.yml
   when: vault_upgrade_required is defined and vault_upgrade_required == true and vault_auto_unseal == true
 
 # Configuring vault only if install is required or if auto unseal is enabled
 - name: Ensure vault configuration files are defined as expected
+  serial: 1
   include: configure.yml
   when: vault_install_required == true or vault_auto_unseal == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,13 +15,11 @@
   when: vault_install_required == true
 
 # Upgrade vault on nodes if the upgrade is required
-- name: Upgrade vault to version "{{ vault_version }}"
+- name: Upgrade vault to version {{ vault_version }}
   include: upgrade.yml
   when: vault_upgrade_required is defined and vault_upgrade_required == true and vault_auto_unseal == true
-  serial: 1
 
 # Configuring vault only if install is required or if auto unseal is enabled
 - name: Ensure vault configuration files are defined as expected
   include: configure.yml
   when: vault_install_required == true or vault_auto_unseal == true
-  serial: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,11 +9,17 @@
   include: requirements.yml
   when: vault_install_required == true
 
-# Installing vault on nodes
+# Installing vault on nodes only if install is required
 - name: Ensure vault is installed
   include: install.yml
-  when: vault_upgrade_required is not defined
+  when: vault_install_required == true
 
-# Configuring vault
-- name: Ensure vault configuration has been done as expected
+# Upgrade vault on nodes if the upgrade is required
+- name: Upgrade vault to version {{ vault_version }}
+  include: install.yml
+  when: vault_upgrade_required is defined and vault_upgrade_required == true
+
+# Configuring vault only if install is required or if auto unseal is enabled
+- name: Ensure vault configuration files are defined as expected
   include: configure.yml
+  when: vault_install_required == true or vault_auto_unseal == true


### PR DESCRIPTION
- Validation de l'installation de vault sur les serveurs
- Si vault est déjà installé, les tâches d'installation ne sont pas déroulées
- Si un upgrade doit être fait, celui-ci ne peut se faire que si l'auto unseal est activé
- Les étapes de configuration ne sont déroulées que sur la first install ou si auto unseal est activé