### PR TITLE
Fix/vault autocomplete install

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -29,7 +29,7 @@
 
 # Checking if vault already installed in the expected version
 - name: Check if vault is already installed
-  command: vault version
+  command: "{{ vault_bin_path }}/vault version"
   register: vault_install_check
   changed_when: false
   ignore_errors: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -114,7 +114,7 @@
   become_user: "{{ vault_user }}"
   register: autocomplete
   failed_when: autocomplete.rc != 0 and autocomplete.rc != 1
-  changed_when: "'already installed' not in autocomplete_install.stderr"
+  changed_when: "'already installed' not in autocomplete.stderr"
 
 - name: Insert http(s) export in dotfile
   lineinfile:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -112,7 +112,9 @@
   args:
     executable: /bin/bash
   become_user: "{{ vault_user }}"
-  ignore_errors: yes
+  register: autocomplete
+  failed_when: autocomplete.rc != 0 and autocomplete.rc != 1
+  changed_when: "'already installed' not in autocomplete_install.stderr"
 
 - name: Insert http(s) export in dotfile
   lineinfile:


### PR DESCRIPTION
Hello Jimmy,

Un fix proposé pour 2 choses : 

1/ Autocomplete : le fix permet en cas d'autocomplete déjà installé de ne pas pêter une erreur + ne pas afficher de "change" (au sens ansible)

2/ vault version : j'ai rajouté le path vers le binaire vault

++